### PR TITLE
Don't filter backtrace when running ruby/spec

### DIFF
--- a/build-ruby.rb
+++ b/build-ruby.rb
@@ -384,7 +384,7 @@ class BuildRuby
 
   def test_rubyspec
     builddir{
-      cmd "#{@make} yes-test-rubyspec MSPECOPT='--error-output stderr' #{@test_opts}", on_failure: :skip
+      cmd "#{@make} yes-test-rubyspec MSPECOPT='--error-output stderr --debug' #{@test_opts}", on_failure: :skip
     }
   end
 


### PR DESCRIPTION
I'm trying to track down the flaky YJIT failure and the full backtrace should be helpful.
